### PR TITLE
Fix nix run with nixGL

### DIFF
--- a/nix/packages/nix-cuda-test.nix
+++ b/nix/packages/nix-cuda-test.nix
@@ -55,10 +55,13 @@ assert wrapWithNixGL -> nixGL != null; let
       ruff
     ];
     postInstall = lib.optionalString wrapWithNixGL ''
-      mv $out/bin/nix-cuda-test $out/bin/.nix-cuda-test-wrapped
-      echo '#!${stdenv.shell}' > $out/bin/${attrs.pname}
-      echo ${lib.getExe nixGL.nixGLNvidia} $out/bin/.nix-cuda-test-wrapped '"$@"' >> $out/bin/${attrs.pname}
-      chmod +x $out/bin/${attrs.pname}
+      mv "$out/bin/nix-cuda-test" "$out/bin/.nix-cuda-test-wrapped"
+      echo '#!${stdenv.shell}' > "$out/bin/${attrs.pname}"
+      echo '"${lib.getExe nixGL.nixGLNvidia}"'\
+        " \"$out/bin/.nix-cuda-test-wrapped\""\
+        '"$@"' \
+        >> "$out/bin/${attrs.pname}"
+      chmod +x "$out/bin/${attrs.pname}"
     '';
     meta = with lib; {
       description = "A test of CUDA with nixpkgs";


### PR DESCRIPTION
This part of the build script handling NixGL wrapping isn't working currently.

This PR fixes the issue by

- Generating the outupt to be `bin/nix-cuda-test-wrapped-nixGL` instead of `bin/nix-cuda-test-wrapped`. The former is the package's name when using NixGL, thus `nix run` wouldn't work before, trying to find the binary with `-nixGL` suffixes by default.
- Make the script executable with `chmod +x`
- Pointing to the right binary path of the NixGLNvidia package
- Correctly interpolating $out in the generated script, which was left uninterpreted (and thus would give an empty shell variable at runtime, when $out doesn't exist anymore), because of the enclosing `''`. The line has also been split on multiple lines (it's a bit more quotes and escaping, but the resulting lines are shorter. I'm happy to revert if you think it's less readable, though)